### PR TITLE
delete only populates for messages from active user

### DIFF
--- a/src/scripts/chat/ChatList.js
+++ b/src/scripts/chat/ChatList.js
@@ -36,6 +36,7 @@ const render = (messagesArr, userArr, target) => {
 <div class="asideRight__chat__output">
 ${messagesArr
   .map((message) => {
+    console.log(message)
     const messageAuthor = userArr.find((user) => {
       return user.id === message.userId
     })

--- a/src/scripts/chat/Message.js
+++ b/src/scripts/chat/Message.js
@@ -2,6 +2,12 @@
 
 export const Message = (userObj, messageObj) => {
   return `
-  <p>${userObj.username}: ${messageObj.message} <button id="deleteMessage--${messageObj.id}" class="btn">delete</button></p>
+  <p>${userObj.username}: ${messageObj.message} ${AddDeleteButton(messageObj)}</p>
   `
+}
+const AddDeleteButton = (messageObj) => {
+  // Only add a delete button if the active user created this event.
+  if (messageObj.userId === +sessionStorage.getItem("activeUser"))
+    return `<button id="deleteMessage--${messageObj.id}" class="btn">Delete</button>`
+  else return ``
 }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -15,7 +15,7 @@ import { Nutshell } from "./Nutshell.js"
 const mainBody = document.querySelector(".mainBody")
 const auth = document.querySelector(".auth")
 
-sessionStorage.setItem("activeUser", 1);
+// sessionStorage.setItem("activeUser", 1);
 // If no activeUser, render loging and Registration form
 
 if (!sessionStorage.activeUser) {


### PR DESCRIPTION
# Description
Delete button only populates for the messages written by the current user.
Fixes # (issue)
## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
# Testing Instructions
have comments written by tow different users in the chat. The delete btn should only appear for the active user.
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
