### PR TITLE
Chat messages are updated across browser tabs when anyone sends a new message

### DIFF
--- a/src/scripts/auth/LoginForm.js
+++ b/src/scripts/auth/LoginForm.js
@@ -8,6 +8,10 @@ eventHub.addEventListener("userAuthenticated", (e) => {
   Nutshell()
 })
 
+eventHub.addEventListener("storage", e => {
+  console.log(e);
+})
+
 eventHub.addEventListener("click", (e) => {
   if (e.target.id === "login__button") {
     const username = document.querySelector("#login__username").value

--- a/src/scripts/chat/ChatList.js
+++ b/src/scripts/chat/ChatList.js
@@ -37,7 +37,6 @@ const render = (messagesArr, userArr, target) => {
 <div class="asideRight__chat__output">
 ${messagesArr
   .map((message) => {
-    console.log(message)
     const messageAuthor = userArr.find((user) => {
       return user.id === message.userId
     })

--- a/src/scripts/chat/chatProvider.js
+++ b/src/scripts/chat/chatProvider.js
@@ -1,9 +1,13 @@
 import { ChatList } from "./ChatList.js"
 let messages = []
+
+// A local copy of the timestamp of the most recent chat message
 let mostRecentChat = 0;
 
 const eventHub = document.querySelector(".container")
 
+// Listen for the storage event that fires every time localStorage is updated. If our local most recent
+// timestamp is lower than the timestamp in localStorage, update our chat list.
 addEventListener("storage", e => {
   if(useMostRecentChat() < parseInt(localStorage.getItem("mostRecentChatMessage"))) {
     getMessages()
@@ -33,14 +37,15 @@ export const getMessages = () => {
 }
 
 export const saveMessage = (message) => {
+  // Update our local most recent time stamp if the new message's timestamp is higher (not guaranteed,
+  // because messages are sent asynchronously)
   if (useMostRecentChat() < message.postTime)
     setMostRecentChat(message.postTime)
-
+  // Compare timestamps to see if we need to update localStorage's timestamp
   if (parseInt(localStorage.getItem("mostRecentChatMessage")) < useMostRecentChat()) {
-    console.log("most recent: ", useMostRecentChat())
     localStorage.setItem("mostRecentChatMessage", useMostRecentChat())
   }
-
+  // If localStorage does not have a timestamp at all, add one.
   if(!localStorage.getItem("mostRecentChatMessage"))
   localStorage.setItem("mostRecentChatMessage", useMostRecentChat())
 

--- a/src/scripts/chat/chatProvider.js
+++ b/src/scripts/chat/chatProvider.js
@@ -1,4 +1,5 @@
 let messages = []
+let mostRecentChat = 0;
 const eventHub = document.querySelector(".container")
 
 const dispatchStateChangeEvent = () => {

--- a/src/scripts/chat/chatProvider.js
+++ b/src/scripts/chat/chatProvider.js
@@ -1,11 +1,24 @@
+import { ChatList } from "./ChatList.js"
 let messages = []
 let mostRecentChat = 0;
+
 const eventHub = document.querySelector(".container")
+
+addEventListener("storage", e => {
+  if(useMostRecentChat() < parseInt(localStorage.getItem("mostRecentChatMessage"))) {
+    getMessages()
+    .then(ChatList)
+  }
+})
 
 const dispatchStateChangeEvent = () => {
   const chatStateChangeEvent = new CustomEvent("chatStateChanged")
   eventHub.dispatchEvent(chatStateChangeEvent)
 }
+
+export const useMostRecentChat = () => mostRecentChat;
+
+export const setMostRecentChat = time => mostRecentChat = time;
 
 export const useMessages = () => {
   return messages.slice().sort((a, b) => b.postTime - a.postTime)
@@ -20,6 +33,17 @@ export const getMessages = () => {
 }
 
 export const saveMessage = (message) => {
+  if (useMostRecentChat() < message.postTime)
+    setMostRecentChat(message.postTime)
+
+  if (parseInt(localStorage.getItem("mostRecentChatMessage")) < useMostRecentChat()) {
+    console.log("most recent: ", useMostRecentChat())
+    localStorage.setItem("mostRecentChatMessage", useMostRecentChat())
+  }
+
+  if(!localStorage.getItem("mostRecentChatMessage"))
+  localStorage.setItem("mostRecentChatMessage", useMostRecentChat())
+
   return fetch("http://localhost:8088/messages", {
     method: "POST",
     headers: {

--- a/src/scripts/friends/FriendProvider.js
+++ b/src/scripts/friends/FriendProvider.js
@@ -20,6 +20,7 @@ export const getFriends = () => {
 const dispatchStateChange = () => {
     eventHub.dispatchEvent(new CustomEvent("friendListStateChanged"));
     eventHub.dispatchEvent(new CustomEvent("eventListStateChanged"));
+    eventHub.dispatchEvent(new CustomEvent("chatListStateChanged"));
 }
 
 // Returns an array of all friends of a particular user. Requires either a user id or a user object.


### PR DESCRIPTION

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
Checkout branch, open two tabs with two different users and send chat messages; both chat windows should update
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
